### PR TITLE
Add dark/light theme toggle with persistence and page-wide styles (#1)

### DIFF
--- a/notes/templates/notes/create_note.html
+++ b/notes/templates/notes/create_note.html
@@ -8,6 +8,11 @@
         border-radius: 8px;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
     }
+body.dark-mode .form-container {
+    background: #23272b;
+    border-color: #444;
+    color: #e2e2e2;
+}
 
     .form-container h2 {
         margin-bottom: 20px;
@@ -26,6 +31,7 @@
         margin-bottom: 6px;
         color: #444;
     }
+body.dark-mode form label { color: #e2e2e2; }
 
     form input[type="text"],
     form textarea {
@@ -36,6 +42,12 @@
         font-size: 1rem;
         transition: border-color 0.2s ease-in-out;
     }
+body.dark-mode form input[type="text"],
+body.dark-mode form textarea {
+    background: #23272b;
+    color: #e2e2e2;
+    border-color: #444;
+}
 
     form input[type="text"]:focus,
     form textarea:focus {
@@ -61,6 +73,7 @@
 </style>
 {% block content %}
 <div class="form-container">
+  {% include 'notes/navbar.html' %}
   <h2>Create a New Note</h2>
   <form method="post">
     {% csrf_token %}

--- a/notes/templates/notes/delete_note.html
+++ b/notes/templates/notes/delete_note.html
@@ -13,6 +13,8 @@
             margin: 0;
         }
 
+        body.dark-mode { background-color: #181a1b; color: #e2e2e2; }
+
         .delete-container {
             background: #fff;
             padding: 25px;
@@ -22,6 +24,8 @@
             width: 100%;
             box-shadow: 0 2px 8px rgba(0,0,0,0.1);
         }
+
+        body.dark-mode .delete-container { background: #23272b; box-shadow: none; border: 1px solid #444; }
 
         .delete-container h2 {
             margin-bottom: 20px;
@@ -63,9 +67,12 @@
         .delete-container a:hover {
             background-color: #565e64;
         }
+
+        body.dark-mode .delete-container a { background-color: #4b5563; }
     </style>
 </head>
 <body>
+    {% include 'notes/navbar.html' %}
     <div class="delete-container">
         <h2>Are you sure you want to delete "<strong>{{ note.title }}</strong>"?</h2>
         

--- a/notes/templates/notes/navbar.html
+++ b/notes/templates/notes/navbar.html
@@ -125,3 +125,29 @@
     </ul>
     <button id="dark-mode-toggle" style="margin-left:20px;padding:6px 12px;border-radius:4px;border:none;background:#333;color:#fff;cursor:pointer;transition:background 0.3s;">Dark Mode</button>
 </nav>
+
+<script>
+  (function() {
+    function setDarkMode(enabled) {
+      document.body.classList.toggle('dark-mode', enabled);
+      try { localStorage.setItem('darkMode', enabled ? '1' : '0'); } catch (e) {}
+      var btn = document.getElementById('dark-mode-toggle');
+      if (btn) { btn.textContent = enabled ? 'Light Mode' : 'Dark Mode'; }
+    }
+    function sync() {
+      var enabled = false;
+      try { enabled = localStorage.getItem('darkMode') === '1'; } catch (e) { enabled = false; }
+      setDarkMode(enabled);
+    }
+    document.addEventListener('DOMContentLoaded', function() {
+      sync();
+      var btn = document.getElementById('dark-mode-toggle');
+      if (btn) {
+        btn.addEventListener('click', function() {
+          var next = !(document.body.classList.contains('dark-mode'));
+          setDarkMode(next);
+        });
+      }
+    });
+  })();
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Smart-Notes",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Added a Dark/Light mode toggle in notes/templates/notes/navbar.html with localStorage persistence.
home.html, create_note.html, and delete_note.html now include styles for .dark-mode and include the navbar so the toggle is available everywhere.
Toggle updates immediately without page reload; prefers last user choice on next visits.