### PR TITLE
Add Export as TXT and Live Word/Character Count Features

### DIFF
--- a/notes/templates/notes/create_note.html
+++ b/notes/templates/notes/create_note.html
@@ -72,6 +72,14 @@
     #markdown-preview {
       border:1px solid #ccc; padding:10px; background:#fafafa; min-height:40px; margin-top:8px;
     }
+    #count-info {
+      font-size:0.95em;
+      color:#555;
+      margin-bottom:8px;
+    }
+    body.dark-mode #count-info {
+      color:#bdbdbd;
+    }
 </style>
 {% block content %}
 <div class="form-container">
@@ -80,6 +88,9 @@
     {% csrf_token %}
     {{ form.title.label_tag }}{{ form.title }}
     {{ form.content.label_tag }}<textarea id="id_content" name="content"></textarea>
+    <div id="count-info">
+      Words: <span id="word-count">0</span> | Characters: <span id="char-count">0</span>
+    </div>
     {{ form.tags.label_tag }}{{ form.tags }}
     <label>Pick a color:</label>
     <div class="color-picker" id="color-picker">
@@ -98,12 +109,17 @@
 </div>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
-  
+  function updateCount() {
+    const val = document.getElementById('id_content').value;
+    document.getElementById('char-count').textContent = val.length;
+    const words = val.trim().split(/\s+/).filter(w => w.length);
+    document.getElementById('word-count').textContent = val.trim() ? words.length : 0;
+  }
   document.getElementById('id_content').addEventListener('input', function() {
+    updateCount();
     document.getElementById('markdown-preview').innerHTML = marked.parse(this.value);
   });
-
-
+  updateCount();
   const picker = document.getElementById('color-picker');
   const options = picker.querySelectorAll('.color-option');
   const colorInput = document.getElementById('selected-color');
@@ -120,7 +136,6 @@
     const title = document.querySelector('[name="title"]').value;
     const color = colorInput.value;
     if(title) {
-      // Save color for this note (keyed by title)
       localStorage.setItem('note-color-' + title, color);
     }
   };

--- a/notes/templates/notes/home.html
+++ b/notes/templates/notes/home.html
@@ -48,18 +48,30 @@
       margin-bottom: 12px;
       transition: color 0.3s;
     }
-    .note-delete {
+    .note-delete, .note-export {
       display: inline-block;
       padding: 6px 12px;
-      background-color: #dc3545;
-      color: #fff;
       border-radius: 4px;
       text-decoration: none;
       font-size: 0.9rem;
       transition: background-color 0.2s ease;
+      margin-right: 8px;
+      cursor: pointer;
+    }
+    .note-delete {
+      background-color: #dc3545;
+      color: #fff;
     }
     .note-delete:hover {
       background-color: #a71d2a;
+    }
+    .note-export {
+      background-color: #1976d2;
+      color: #fff;
+      border: none;
+    }
+    .note-export:hover {
+      background-color: #004ba0;
     }
     body.dark-mode {
       background: #181a1b;
@@ -86,6 +98,13 @@
     body.dark-mode .note-delete:hover {
       background-color: #7f0000;
     }
+    body.dark-mode .note-export {
+      background-color: #1565c0;
+      color: #fff;
+    }
+    body.dark-mode .note-export:hover {
+      background-color: #002171;
+    }
     </style>
 </head>
 <body>
@@ -107,6 +126,7 @@
               <div class="note-content">{{ note.content }}</div>
               <p class="note-tags">Tags: {{ note.tags }}</p>
               <a class="note-delete" href="{% url 'delete_note' note.id %}">Delete</a>
+              <button class="note-export" onclick="exportNote('{{ note.title|escapejs }}', `{{ note.content|escapejs }}`, `{{ note.tags|escapejs }}`)">Export</button>
           </div>
       {% endfor %}
     </div>
@@ -154,11 +174,23 @@
           const title = card.dataset.title;
           const color = localStorage.getItem('note-color-' + title);
           if(color) card.style.background = color;
-          // Markdown render for note content
           const nc = card.querySelector('.note-content');
           if (nc) nc.innerHTML = marked.parse(nc.textContent);
         });
       });
+
+      function exportNote(title, content, tags) {
+        const text = `Title: ${title}\nTags: ${tags}\n\n${content}`;
+        const blob = new Blob([text], { type: 'text/plain' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${title}.txt`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
     </script>
 </body>
 </html>


### PR DESCRIPTION
This PR introduces two user-friendly features to improve the notes experience:

- **Export as TXT**:  
  Each note card now includes an "Export" button, allowing users to download individual notes as `.txt` files containing the title, tags, and content.

- **Live Word/Character Count**:  
  While creating a note, users can see real-time word and character counts below the content field for better composition awareness.

Both features are implemented on the frontend for speed and simplicity.
